### PR TITLE
feat(验证器): 增强 NotBlank 装饰器以支持可选未赋值字段验证

### DIFF
--- a/pydantic_validation_decorator/not_blank.py
+++ b/pydantic_validation_decorator/not_blank.py
@@ -14,15 +14,14 @@ class NotBlank:
     def __init__(
         self,
         field_name: str,
-        allow_unset: bool = False,
+        allow_unset: Optional[bool] = False,
         message: Optional[str] = None,
     ):
         """Field NotBlank Validation Decorator
 
         Args:
             field_name (str): Field name that need to be validated.
-            allow_unset (bool, optional): If True, validation only runs when the optional field
-                                          is explicitly provided. Defaults to False.
+            allow_unset (Optional[bool], optional): If True, validation only runs when the optional field is explicitly provided. Defaults to False.
             message (Optional[str], optional): Prompt message for validation failure. Defaults to None.
         """
         self.field_name = field_name
@@ -37,8 +36,9 @@ class NotBlank:
             async def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    should_validate = (not self.allow_unset) or \
-                                      (self.allow_unset and self.field_name in validate_model.model_fields_set)
+                    should_validate = (not self.allow_unset) or (
+                        self.allow_unset and self.field_name in validate_model.model_fields_set
+                    )
                     if should_validate:
                         field_value = getattr(validate_model, self.field_name)
                         if (
@@ -64,8 +64,9 @@ class NotBlank:
             def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    should_validate = (not self.allow_unset) or \
-                                      (self.allow_unset and self.field_name in validate_model.model_fields_set)
+                    should_validate = (not self.allow_unset) or (
+                        self.allow_unset and self.field_name in validate_model.model_fields_set
+                    )
                     if should_validate:
                         field_value = getattr(validate_model, self.field_name)
                         if (

--- a/pydantic_validation_decorator/not_blank.py
+++ b/pydantic_validation_decorator/not_blank.py
@@ -7,21 +7,26 @@ from .exceptions import FieldValidationError
 
 class NotBlank:
     """
-    Field NotBlank Validation Decorator
+    Field NotBlank Validation Decorator.
+    Can validate required fields, or optional fields if they are set.
     """
 
     def __init__(
         self,
         field_name: str,
+        allow_optional: bool = False,
         message: Optional[str] = None,
     ):
         """Field NotBlank Validation Decorator
 
         Args:
-            field_name (str): Field name that need to be validate.
+            field_name (str): Field name that need to be validated.
+            allow_optional (bool, optional): If True, validation only runs when the optional field
+                                             is explicitly provided. Defaults to False.
             message (Optional[str], optional): Prompt message for validation failure. Defaults to None.
         """
         self.field_name = field_name
+        self.allow_optional = allow_optional
         self.message = message
 
     def __call__(self, func):
@@ -32,21 +37,24 @@ class NotBlank:
             async def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    field_value = getattr(validate_model, self.field_name)
-                    if (
-                        field_value is None
-                        or field_value == ''
-                        or field_value == []
-                        or field_value == ()
-                        or field_value == {}
-                    ):
-                        raise FieldValidationError(
-                            model_name=validate_model.__class__.__name__,
-                            field_name=self.field_name,
-                            field_value=field_value,
-                            validator=self.__class__.__name__,
-                            message=self.message if self.message else f'{self.field_name} cannot be empty.',
-                        )
+                    should_validate = (not self.allow_optional) or \
+                                      (self.allow_optional and self.field_name in validate_model.model_fields_set)
+                    if should_validate:
+                        field_value = getattr(validate_model, self.field_name)
+                        if (
+                            field_value is None
+                            or field_value == ''
+                            or field_value == []
+                            or field_value == ()
+                            or field_value == {}
+                        ):
+                            raise FieldValidationError(
+                                model_name=validate_model.__class__.__name__,
+                                field_name=self.field_name,
+                                field_value=field_value,
+                                validator=self.__class__.__name__,
+                                message=self.message if self.message else f'{self.field_name} cannot be empty.',
+                            )
                 return await func(*args, **kwargs)
 
             return wrapper
@@ -56,21 +64,24 @@ class NotBlank:
             def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    field_value = getattr(validate_model, self.field_name)
-                    if (
-                        field_value is None
-                        or field_value == ''
-                        or field_value == []
-                        or field_value == ()
-                        or field_value == {}
-                    ):
-                        raise FieldValidationError(
-                            model_name=validate_model.__class__.__name__,
-                            field_name=self.field_name,
-                            field_value=field_value,
-                            validator=self.__class__.__name__,
-                            message=self.message if self.message else f'{self.field_name} cannot be empty.',
-                        )
+                    should_validate = (not self.allow_optional) or \
+                                      (self.allow_optional and self.field_name in validate_model.model_fields_set)
+                    if should_validate:
+                        field_value = getattr(validate_model, self.field_name)
+                        if (
+                            field_value is None
+                            or field_value == ''
+                            or field_value == []
+                            or field_value == ()
+                            or field_value == {}
+                        ):
+                            raise FieldValidationError(
+                                model_name=validate_model.__class__.__name__,
+                                field_name=self.field_name,
+                                field_value=field_value,
+                                validator=self.__class__.__name__,
+                                message=self.message if self.message else f'{self.field_name} cannot be empty.',
+                            )
                 return func(*args, **kwargs)
 
             return wrapper

--- a/pydantic_validation_decorator/not_blank.py
+++ b/pydantic_validation_decorator/not_blank.py
@@ -14,19 +14,19 @@ class NotBlank:
     def __init__(
         self,
         field_name: str,
-        allow_optional: bool = False,
+        allow_unset: bool = False,
         message: Optional[str] = None,
     ):
         """Field NotBlank Validation Decorator
 
         Args:
             field_name (str): Field name that need to be validated.
-            allow_optional (bool, optional): If True, validation only runs when the optional field
-                                             is explicitly provided. Defaults to False.
+            allow_unset (bool, optional): If True, validation only runs when the optional field
+                                          is explicitly provided. Defaults to False.
             message (Optional[str], optional): Prompt message for validation failure. Defaults to None.
         """
         self.field_name = field_name
-        self.allow_optional = allow_optional
+        self.allow_unset = allow_unset
         self.message = message
 
     def __call__(self, func):
@@ -37,8 +37,8 @@ class NotBlank:
             async def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    should_validate = (not self.allow_optional) or \
-                                      (self.allow_optional and self.field_name in validate_model.model_fields_set)
+                    should_validate = (not self.allow_unset) or \
+                                      (self.allow_unset and self.field_name in validate_model.model_fields_set)
                     if should_validate:
                         field_value = getattr(validate_model, self.field_name)
                         if (
@@ -64,8 +64,8 @@ class NotBlank:
             def wrapper(*args, **kwargs):
                 validate_model = args[0]
                 if isinstance(validate_model, BaseModel) and hasattr(validate_model, self.field_name):
-                    should_validate = (not self.allow_optional) or \
-                                      (self.allow_optional and self.field_name in validate_model.model_fields_set)
+                    should_validate = (not self.allow_unset) or \
+                                      (self.allow_unset and self.field_name in validate_model.model_fields_set)
                     if should_validate:
                         field_value = getattr(validate_model, self.field_name)
                         if (

--- a/tests/test_not_blank_decorator.py
+++ b/tests/test_not_blank_decorator.py
@@ -102,6 +102,38 @@ class TestNotBlankDecorator:
         assert result == {'user_name': '  test  '}
         assert result['user_name'] == '  test  '
 
+    def test_not_blank_allow_unset_with_unset_field(self):
+        """测试 allow_unset=True 且字段未设置的情况，应该跳过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel()
+        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+        assert result == {'user_type': None}
+
+    def test_not_blank_allow_unset_with_set_field_none_value(self):
+        """测试 allow_unset=True 且字段被设置为 None 的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type=None)
+        with pytest.raises(FieldValidationError) as exc_info:
+            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    def test_not_blank_allow_unset_with_set_field_empty_string(self):
+        """测试 allow_unset=True 且字段被设置为空字符串的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='')
+        with pytest.raises(FieldValidationError) as exc_info:
+            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    def test_not_blank_allow_unset_with_set_field_valid_value(self):
+        """测试 allow_unset=True 且字段被设置为有效值的情况，应该通过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='test123')
+        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+        assert result == {'user_type': 'test123'}
+
     @pytest.mark.asyncio
     async def test_async_not_blank_decorator_valid_input(self):
         """测试异步装饰器有效输入（非空字符串）"""
@@ -148,40 +180,6 @@ class TestNotBlankDecorator:
         result = await async_test_not_blank_decorator(not_blank_test)
         assert result == {'user_name': '  test  '}
         assert result['user_name'] == '  test  '
-
-    # Tests for allow_unset parameter
-    def test_not_blank_allow_unset_with_unset_field(self):
-        """测试 allow_unset=True 且字段未设置的情况，应该跳过验证"""
-        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel()
-        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
-        assert result == {'user_type': None}
-
-    def test_not_blank_allow_unset_with_set_field_none_value(self):
-        """测试 allow_unset=True 且字段被设置为 None 的情况，应该触发验证错误"""
-        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type=None)
-        with pytest.raises(FieldValidationError) as exc_info:
-            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
-
-        error = exc_info.value
-        assert error.field_name == 'user_type'
-        assert 'user_type cannot be blank' in error.message
-
-    def test_not_blank_allow_unset_with_set_field_empty_string(self):
-        """测试 allow_unset=True 且字段被设置为空字符串的情况，应该触发验证错误"""
-        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='')
-        with pytest.raises(FieldValidationError) as exc_info:
-            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
-
-        error = exc_info.value
-        assert error.field_name == 'user_type'
-        assert 'user_type cannot be blank' in error.message
-
-    def test_not_blank_allow_unset_with_set_field_valid_value(self):
-        """测试 allow_unset=True 且字段被设置为有效值的情况，应该通过验证"""
-        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='test123')
-        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
-        assert result == {'user_type': 'test123'}
-
 
     @pytest.mark.asyncio
     async def test_async_not_blank_allow_unset_with_unset_field(self):

--- a/tests/test_not_blank_decorator.py
+++ b/tests/test_not_blank_decorator.py
@@ -22,16 +22,39 @@ class NotBlankTestModel(BaseModel):
         self.get_user_name()
 
 
+class NotBlankAllowUnsetTestModel(BaseModel):
+    user_type: Optional[str] = None
+
+    @NotBlank(
+        field_name='user_type',
+        allow_unset=True,
+        message='user_type cannot be blank',
+    )
+    def get_user_type(self):
+        return self.user_type
+
+    def validate_fields(self):
+        self.get_user_type()
+
+
 @ValidateFields(validate_model='not_blank_test', validate_function='get_user_name')
 def sync_test_not_blank_decorator(not_blank_test: NotBlankTestModel):
     return not_blank_test.model_dump()
 
 
 @ValidateFields(mode='args', validate_model_index=0)
-async def async_test_not_blank_decorator(
-    not_blank_test: NotBlankTestModel,
-):
+async def async_test_not_blank_decorator(not_blank_test: NotBlankTestModel):
     return not_blank_test.model_dump()
+
+
+@ValidateFields(validate_model='not_blank_allow_unset_test', validate_function='get_user_type')
+def sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test: NotBlankAllowUnsetTestModel):
+    return not_blank_allow_unset_test.model_dump()
+
+
+@ValidateFields(mode='args', validate_model_index=0)
+async def async_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test: NotBlankAllowUnsetTestModel):
+    return not_blank_allow_unset_test.model_dump()
 
 
 class TestNotBlankDecorator:
@@ -125,3 +148,73 @@ class TestNotBlankDecorator:
         result = await async_test_not_blank_decorator(not_blank_test)
         assert result == {'user_name': '  test  '}
         assert result['user_name'] == '  test  '
+
+    # Tests for allow_unset parameter
+    def test_not_blank_allow_unset_with_unset_field(self):
+        """测试 allow_unset=True 且字段未设置的情况，应该跳过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel()
+        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+        assert result == {'user_type': None}
+
+    def test_not_blank_allow_unset_with_set_field_none_value(self):
+        """测试 allow_unset=True 且字段被设置为 None 的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type=None)
+        with pytest.raises(FieldValidationError) as exc_info:
+            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    def test_not_blank_allow_unset_with_set_field_empty_string(self):
+        """测试 allow_unset=True 且字段被设置为空字符串的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='')
+        with pytest.raises(FieldValidationError) as exc_info:
+            sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    def test_not_blank_allow_unset_with_set_field_valid_value(self):
+        """测试 allow_unset=True 且字段被设置为有效值的情况，应该通过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='test123')
+        result = sync_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test=not_blank_allow_unset_test)
+        assert result == {'user_type': 'test123'}
+
+
+    @pytest.mark.asyncio
+    async def test_async_not_blank_allow_unset_with_unset_field(self):
+        """测试异步 allow_unset=True 且字段未设置的情况，应该跳过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel()
+        result = await async_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test)
+        assert result == {'user_type': None}
+
+    @pytest.mark.asyncio
+    async def test_async_not_blank_allow_unset_with_set_field_none_value(self):
+        """测试异步 allow_unset=True 且字段被设置为 None 的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type=None)
+        with pytest.raises(FieldValidationError) as exc_info:
+            await async_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    @pytest.mark.asyncio
+    async def test_async_not_blank_allow_unset_with_set_field_empty_string(self):
+        """测试异步 allow_unset=True 且字段被设置为空字符串的情况，应该触发验证错误"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='')
+        with pytest.raises(FieldValidationError) as exc_info:
+            await async_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test)
+
+        error = exc_info.value
+        assert error.field_name == 'user_type'
+        assert 'user_type cannot be blank' in error.message
+
+    @pytest.mark.asyncio
+    async def test_async_not_blank_allow_unset_with_set_field_valid_value(self):
+        """测试异步 allow_unset=True 且字段被设置为有效值的情况，应该通过验证"""
+        not_blank_allow_unset_test = NotBlankAllowUnsetTestModel(user_type='test123')
+        result = await async_test_not_blank_allow_unset_decorator(not_blank_allow_unset_test)
+        assert result == {'user_type': 'test123'}


### PR DESCRIPTION
原有的 `NotBlank` 装饰器会始终执行其验证逻辑，这使其不适用于那些“字段可选，但一旦提供就不能为空”的验证场景。

本次提交通过引入一个新的布尔参数 `allow_optional` 来增强此装饰器。

- `allow_optional` 的默认值为 `False`，这确保了完全的向后兼容性。所有现有的装饰器用法无需任何修改即可正常工作。

- 当 `allow_optional` 设置为 `True` 时，装饰器将仅在该字段被显式提供（即存在于 Pydantic 模型的 `model_fields_set` 中）时，才执行非空验证。

此次变更极大地提高了该装饰器的通用性和灵活性，使其能覆盖更多的验证场景，并减少了为可选字段编写自定义验证逻辑或独立装饰器的需要。

可选字段使用示例:
@NotBlank(field_name='nickname', allow_optional=True)